### PR TITLE
fix: align sold-out threshold to Available < 30 across PDF, backend, and Produkter

### DIFF
--- a/App.Tests/ProductStatusTests.cs
+++ b/App.Tests/ProductStatusTests.cs
@@ -17,9 +17,15 @@ public class ProductStatusTests
     }
 
     [Fact]
-    public void StatusFor_AtThreshold_ReturnsSoldOut()
+    public void StatusFor_AtThreshold_ReturnsAvailable()
     {
-        Assert.Equal(ProductStatus.SoldOut, Product.StatusFor(30));
+        Assert.Equal(ProductStatus.Available, Product.StatusFor(30));
+    }
+
+    [Fact]
+    public void StatusFor_JustBelowThreshold_ReturnsSoldOut()
+    {
+        Assert.Equal(ProductStatus.SoldOut, Product.StatusFor(29));
     }
 
     [Fact]

--- a/App/Components/Pages/ProdukterPage.razor
+++ b/App/Components/Pages/ProdukterPage.razor
@@ -174,7 +174,7 @@
                     {
                         @foreach (var p in rows)
                         {
-                            var soldOut = p.Available <= Product.SoldOutThreshold;
+                            var soldOut = p.Available < Product.SoldOutThreshold;
                             <tr class="prod-row">
                                 <td class="prod-cell">@p.OctopusId</td>
                                 <td class="prod-cell">@p.WebId</td>
@@ -453,9 +453,9 @@
             q = q.Where(p => p.Category == _catFilter);
 
         if (_statusFilter == "Tilgængelig")
-            q = q.Where(p => p.Available > Product.SoldOutThreshold);
+            q = q.Where(p => p.Available >= Product.SoldOutThreshold);
         else if (_statusFilter == "Udsolgt")
-            q = q.Where(p => p.Available <= Product.SoldOutThreshold);
+            q = q.Where(p => p.Available < Product.SoldOutThreshold);
 
         if (_inUseFilter == "I brug")
             q = q.Where(p => p.InUse);

--- a/App/Models/Product.cs
+++ b/App/Models/Product.cs
@@ -11,7 +11,7 @@ public class Product
     public ProductStatus Status => StatusFor(Available);
 
     public static ProductStatus StatusFor(int available)
-        => available <= SoldOutThreshold ? ProductStatus.SoldOut : ProductStatus.Available;
+        => available < SoldOutThreshold ? ProductStatus.SoldOut : ProductStatus.Available;
 
     // Tidligere VareNr
     [Key]

--- a/App/Services/PriceListBuilder.cs
+++ b/App/Services/PriceListBuilder.cs
@@ -24,7 +24,7 @@ public class PriceListBuilder(ProductService productService, CategoryService cat
                     ? products.Select(p => new ProductRow
                     {
                         Product = p,
-                        Status  = p.Available < 30 ? "Udsolgt" : ""
+                        Status  = p.Status == ProductStatus.SoldOut ? "Udsolgt" : ""
                     }).ToList()
                     : []
             })


### PR DESCRIPTION
## Summary
- The PDF's rule (`Available < 30` → *Udsolgt*) is the correct one. `Product.StatusFor` and the Produkter-page filter were using `<= 30`, so a product with exactly 30 in stock was flagged sold out on the Produkter page but shown available on the PDF.
- Flip `Product.StatusFor` and the Produkter status filter to `<` so the threshold means "less than 30 → sold out".
- Have `PriceListBuilder` reuse `p.Status == ProductStatus.SoldOut` instead of duplicating the inline `Available < 30` check, so there's a single source of truth.
- Updated `ProductStatusTests` accordingly (at-threshold is now Available; added a just-below-threshold case).

## Test plan
- [x] `dotnet build Klosterbryggeriet.slnx --configuration Release` — clean
- [x] `dotnet test App.Tests/App.Tests.csproj` — 31/31 passing (Docker running for Testcontainers)
- [ ] Generer prisliste and confirm a product with `Available = 30` is **not** marked *Udsolgt*
- [ ] On Produkter, status filter *Udsolgt* excludes `Available = 30`; *Tilgængelig* includes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)