### PR TITLE
feat(produkter): recover lost polish from Rider shelf

### DIFF
--- a/App/Components/EditableField.razor.css
+++ b/App/Components/EditableField.razor.css
@@ -1,0 +1,114 @@
+.ef-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+    padding: 0.45rem 0.55rem;
+    margin: 0 -0.55rem;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    transition: background 0.1s ease, border-color 0.1s ease;
+}
+
+.ef-row.is-dirty {
+    background: rgba(166, 95, 43, 0.06);
+    border-color: rgba(166, 95, 43, 0.25);
+}
+
+.ef-row.ef-editing {
+    background: #ffffff;
+    border-color: #a65f2b;
+    box-shadow: 0 0 0 3px rgba(166, 95, 43, 0.14);
+}
+
+.ef-label {
+    font-size: 0.66rem;
+    font-weight: 700;
+    color: #8a7356;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.ef-display {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    background: none;
+    border: none;
+    padding: 0.15rem 0;
+    cursor: pointer;
+    font-family: inherit;
+    color: inherit;
+    text-align: left;
+    width: 100%;
+    border-radius: 4px;
+    transition: background 0.1s ease;
+    min-height: 1.6rem;
+}
+
+.ef-display:hover { background: rgba(166, 95, 43, 0.06); }
+
+.ef-value-text {
+    font-size: 0.92rem;
+    color: #221812;
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    flex: 1;
+}
+
+.ef-placeholder {
+    color: #c9b9a0;
+}
+
+.ef-pencil {
+    color: #c9b9a0;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.1s ease, color 0.1s ease;
+    display: inline-flex;
+}
+
+.ef-display:hover .ef-pencil { opacity: 1; color: #a65f2b; }
+
+.ef-row.is-dirty .ef-pencil { opacity: 0.6; color: #a65f2b; }
+
+.ef-row.ef-missing .ef-value-text {
+    color: #E65100;
+}
+
+.ef-input {
+    width: 100%;
+    border: none;
+    outline: none;
+    background: #faf5ec;
+    border-radius: 6px;
+    padding: 0.4rem 0.55rem;
+    font-size: 0.92rem;
+    font-family: inherit;
+    color: #221812;
+    font-variant-numeric: tabular-nums;
+    box-sizing: border-box;
+    -moz-appearance: textfield;
+}
+
+.ef-input:focus { background: #ffffff; }
+
+.ef-input::-webkit-outer-spin-button,
+.ef-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+
+.mangler-chip {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.05rem 0.4rem;
+    background: rgba(230, 81, 0, 0.12);
+    color: #E65100;
+    border-radius: 10px;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    vertical-align: middle;
+}

--- a/App/Components/Pages/ProdukterPage.razor
+++ b/App/Components/Pages/ProdukterPage.razor
@@ -11,11 +11,8 @@
 
 <section class="produkter-page">
     <div class="produkter-header">
-        <div class="produkter-header-text">
-            <p class="produkter-eyebrow">Katalog</p>
-            <h1 class="produkter-title">Produkter</h1>
-            <p class="produkter-lede">@_products.Count produkter i databasen</p>
-        </div>
+        <h1 class="produkter-title">Produkter</h1>
+        <span class="produkter-count">@_products.Count i databasen</span>
     </div>
 
     @if (_loading)
@@ -207,24 +204,10 @@
                     <div class="detail-section">
                         <p class="detail-section-label">Status &amp; lager</p>
                         <div class="status-row">
-                            <div class="status-tile @(_editingField == "Available" ? "status-tile-editing" : "") @(FieldDirty("Available") ? "is-dirty" : "")">
+                            <div class="status-tile">
                                 <span class="status-dot status-dot-lg @dotClass"></span>
-                                @if (_editingField == "Available")
-                                {
-                                    <input @ref="_availableRef" class="status-input" type="number"
-                                           value="@d.Available"
-                                           @oninput="e => { if (int.TryParse(e.Value?.ToString(), out var v)) d.Available = v; }"
-                                           @onblur="EndEdit"
-                                           @onkeydown="HandleEditKey" />
-                                }
-                                else
-                                {
-                                    <button type="button" class="status-value-btn"
-                                            @onclick='() => BeginEditAvailable()'>
-                                        <span class="status-value">@d.Available</span>
-                                        <span class="status-value-label">Disponibel</span>
-                                    </button>
-                                }
+                                <span class="status-value">@d.Available</span>
+                                <span class="status-value-label">Disponibel</span>
                             </div>
 
                             <button type="button"
@@ -304,7 +287,6 @@
                                            InputType="number" Step="0.01"
                                            IsEditing="@(_editingField == "Str")"
                                            IsDirty="@FieldDirty("Str")"
-                                           IsMissing="@(d.Str == 0)"
                                            OnBeginEdit='@(() => BeginEdit("Str"))'
                                            OnEndEdit="EndEdit"
                                            OnInput="@(v => { if (double.TryParse(v, NumberStyles.Any, CultureInfo.InvariantCulture, out var n)) d.Str = n; else if (string.IsNullOrWhiteSpace(v)) d.Str = 0; })" />
@@ -315,7 +297,6 @@
                                            InputType="number" Step="0.1"
                                            IsEditing="@(_editingField == "Alcohol")"
                                            IsDirty="@FieldDirty("Alcohol")"
-                                           IsMissing="@(d.Alcohol == 0)"
                                            OnBeginEdit='@(() => BeginEdit("Alcohol"))'
                                            OnEndEdit="EndEdit"
                                            OnInput="@(v => { if (double.TryParse(v, NumberStyles.Any, CultureInfo.InvariantCulture, out var n)) d.Alcohol = n; else if (string.IsNullOrWhiteSpace(v)) d.Alcohol = 0; })" />
@@ -378,6 +359,33 @@
 
                     <div class="detail-spacer"></div>
 
+                    <div class="detail-danger">
+                        @if (_confirmingDelete)
+                        {
+                            <div class="delete-confirm">
+                                <p class="delete-confirm-text">
+                                    Slet <strong>#@d.OctopusId @d.OctopusTitle</strong> permanent? Denne handling kan ikke fortrydes.
+                                </p>
+                                <div class="delete-confirm-actions">
+                                    <button class="btn-ghost" type="button"
+                                            @onclick="() => _confirmingDelete = false"
+                                            disabled="@_deleting">Annuller</button>
+                                    <button class="btn-danger" type="button"
+                                            @onclick="DeleteSelected" disabled="@_deleting">
+                                        @(_deleting ? "Sletter…" : "Ja, slet permanent")
+                                    </button>
+                                </div>
+                            </div>
+                        }
+                        else
+                        {
+                            <button class="delete-trigger" type="button"
+                                    @onclick="() => _confirmingDelete = true">
+                                Slet produkt
+                            </button>
+                        }
+                    </div>
+
                     @if (dirtyCount > 0 || _saving)
                     {
                         <div class="save-bar">
@@ -427,17 +435,17 @@
     private Product? _original;
     private Product? _draft;
     private string? _editingField;
-    private bool _focusAvailableOnRender;
-    private ElementReference _availableRef;
     private string _saveError = "";
     private bool _saving;
     private int? _pendingSwitchTo;
 
+    // Delete
+    private bool _confirmingDelete;
+    private bool _deleting;
+
     private static readonly (string Key, string Label, Func<Product, bool> Check)[] MissingOptions =
     [
         ("PdfTitle",    "PDF-titel mangler",    p => string.IsNullOrWhiteSpace(p.PdfTitle)),
-        ("Alcohol",     "Alkohol% mangler",     p => p.Alcohol == 0),
-        ("Str",         "Størrelse mangler",    p => p.Str == 0),
         ("KegCollar",   "Kasse/Kolli mangler",  p => (p.KegCollar ?? 0) == 0),
         ("PricePrUnit", "Pris mangler",         p => p.PricePrUnit == 0),
     ];
@@ -466,15 +474,6 @@
         _loading = false;
         var first = SortProducts(_products).FirstOrDefault();
         if (first != null) DoSelect(first.OctopusId);
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (_focusAvailableOnRender && _editingField == "Available")
-        {
-            _focusAvailableOnRender = false;
-            try { await _availableRef.FocusAsync(); } catch { /* element gone */ }
-        }
     }
 
     private List<Product> FilteredProducts()
@@ -558,6 +557,7 @@
         _editingField = null;
         _saveError = "";
         _pendingSwitchTo = null;
+        _confirmingDelete = false;
     }
 
     private void ConfirmSwitchDiscard()
@@ -574,20 +574,9 @@
         _editingField = field;
     }
 
-    private void BeginEditAvailable()
-    {
-        BeginEdit("Available");
-        _focusAvailableOnRender = true;
-    }
-
     private void EndEdit()
     {
         _editingField = null;
-    }
-
-    private void HandleEditKey(KeyboardEventArgs e)
-    {
-        if (e.Key == "Enter" || e.Key == "Escape") EndEdit();
     }
 
     private void ToggleInUse()
@@ -641,6 +630,33 @@
         _draft = Clone(_original);
         _editingField = null;
         _saveError = "";
+    }
+
+    private async Task DeleteSelected()
+    {
+        if (_draft == null) return;
+        var idToRemove = _draft.OctopusId;
+        _deleting = true;
+        _saveError = "";
+        try
+        {
+            await ProductService.DeleteAsync(idToRemove);
+            _products = await ProductService.ListProducts();
+            _confirmingDelete = false;
+            _draft = null;
+            _original = null;
+            _selectedId = null;
+            var next = SortProducts(_products).FirstOrDefault();
+            if (next != null) DoSelect(next.OctopusId);
+        }
+        catch (Exception ex)
+        {
+            _saveError = $"Kunne ikke slette: {ex.Message}";
+        }
+        finally
+        {
+            _deleting = false;
+        }
     }
 
     private async Task SaveDraft()

--- a/App/Components/Pages/ProdukterPage.razor.css
+++ b/App/Components/Pages/ProdukterPage.razor.css
@@ -2,7 +2,7 @@
 .produkter-page {
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2.5rem 0.5rem 1.5rem;
+    padding: 1rem 0.5rem 0.75rem;
     min-width: 0;
     height: calc(100vh - 4.6rem);
     display: flex;
@@ -11,35 +11,24 @@
 
 .produkter-header {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 2rem;
-    margin-bottom: 1.5rem;
-}
-
-.produkter-eyebrow {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: #a65f2b;
-    margin: 0 0 0.9rem;
+    align-items: baseline;
+    gap: 0.85rem;
+    margin-bottom: 0.6rem;
 }
 
 .produkter-title {
     font-family: Georgia, 'Times New Roman', serif;
-    font-size: 2.25rem;
+    font-size: 1.4rem;
     font-weight: 700;
     line-height: 1.15;
     color: #221812;
-    margin: 0 0 0.6rem;
-    letter-spacing: -0.01em;
+    margin: 0;
+    letter-spacing: -0.005em;
 }
 
-.produkter-lede {
+.produkter-count {
+    font-size: 0.78rem;
     color: #8a7356;
-    font-size: 0.92rem;
-    margin: 0;
 }
 
 .produkter-empty {
@@ -51,8 +40,8 @@
 /* ── Filter bar ──────────────────────────────────────────────────────────── */
 .filter-bar {
     display: flex;
-    gap: 0.625rem;
-    margin-bottom: 0.75rem;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
     flex-wrap: wrap;
     align-items: center;
 }
@@ -271,9 +260,9 @@
 
 /* ── Results line ────────────────────────────────────────────────────────── */
 .results-line {
-    font-size: 0.78rem;
+    font-size: 0.74rem;
     color: #8a7356;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
 }
 
 .results-accent {
@@ -313,6 +302,7 @@
     flex-direction: column;
     border-right: 1px solid rgba(109, 68, 35, 0.14);
     min-width: 0;
+    min-height: 0;
     background: #ffffff;
 }
 
@@ -479,6 +469,7 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;
     overflow-y: auto;
     background: #ffffff;
     position: relative;
@@ -513,25 +504,25 @@
 
 /* Detail header */
 .detail-head {
-    padding: 1.4rem 1.75rem 1.1rem;
+    padding: 0.75rem 1.5rem 0.6rem;
     border-bottom: 1px solid rgba(109, 68, 35, 0.08);
 }
 
 .detail-eyebrow {
-    font-size: 0.66rem;
+    font-size: 0.62rem;
     font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: #a65f2b;
-    margin: 0 0 0.4rem;
+    margin: 0 0 0.2rem;
 }
 
 .detail-title {
     font-family: Georgia, 'Times New Roman', serif;
-    font-size: 1.55rem;
+    font-size: 1.2rem;
     font-weight: 700;
     color: #221812;
-    margin: 0 0 0.4rem;
+    margin: 0 0 0.2rem;
     line-height: 1.18;
     letter-spacing: -0.005em;
 }
@@ -588,19 +579,19 @@
 
 /* Detail sections */
 .detail-section {
-    padding: 1.1rem 1.75rem;
+    padding: 0.55rem 1.5rem;
     border-bottom: 1px solid rgba(109, 68, 35, 0.06);
 }
 
 .detail-section:last-of-type { border-bottom: none; }
 
 .detail-section-label {
-    font-size: 0.66rem;
+    font-size: 0.62rem;
     font-weight: 700;
     color: #8a7356;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    margin: 0 0 0.85rem;
+    margin: 0 0 0.4rem;
 }
 
 /* ── Status & lager row ─────────────────────────────────────────────────── */
@@ -613,42 +604,15 @@
 
 .status-tile {
     display: inline-flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.55rem;
     padding: 0.45rem 0.85rem 0.45rem 0.7rem;
     border-radius: 10px;
     background: #faf5ec;
     border: 1px solid rgba(109, 68, 35, 0.14);
-    transition: background 0.12s ease, border-color 0.12s ease;
 }
 
-.status-tile:hover {
-    background: #f0e8d9;
-    border-color: rgba(166, 95, 43, 0.3);
-}
-
-.status-tile.is-dirty {
-    border-color: #a65f2b;
-    background: rgba(166, 95, 43, 0.1);
-}
-
-.status-tile-editing {
-    background: #ffffff;
-    border-color: #a65f2b;
-    box-shadow: 0 0 0 3px rgba(166, 95, 43, 0.14);
-}
-
-.status-value-btn {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.4rem;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    font-family: inherit;
-    color: inherit;
-}
+.status-tile .status-dot-lg { align-self: center; }
 
 .status-value {
     font-size: 1.05rem;
@@ -664,22 +628,6 @@
     letter-spacing: 0.06em;
     text-transform: uppercase;
 }
-
-.status-input {
-    width: 70px;
-    border: none;
-    outline: none;
-    background: transparent;
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: #221812;
-    font-family: inherit;
-    font-variant-numeric: tabular-nums;
-    padding: 0;
-    -moz-appearance: textfield;
-}
-.status-input::-webkit-outer-spin-button,
-.status-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
 
 /* Toggle pills (InUse / HalfKolli) */
 .toggle-pill {
@@ -734,112 +682,76 @@
     box-shadow: 0 0 0 2px rgba(166, 95, 43, 0.25);
 }
 
-/* ── Editable field (used by EditableField component) ───────────────────── */
+/* ── Editable field grid (the EditableField component itself owns its styles
+   in EditableField.razor.css; only the grid that lays them out lives here) ─ */
 .ef-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.5rem 1.25rem;
+    gap: 0.15rem 1.25rem;
 }
 
-.ef-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-    min-width: 0;
-    padding: 0.45rem 0.55rem;
-    margin: 0 -0.55rem;
-    border-radius: 8px;
-    border: 1px solid transparent;
-    transition: background 0.1s ease, border-color 0.1s ease;
-}
-
-.ef-row.is-dirty {
-    background: rgba(166, 95, 43, 0.06);
-    border-color: rgba(166, 95, 43, 0.25);
-}
-
-.ef-row.ef-editing {
-    background: #ffffff;
-    border-color: #a65f2b;
-    box-shadow: 0 0 0 3px rgba(166, 95, 43, 0.14);
-}
-
-.ef-label {
-    font-size: 0.66rem;
-    font-weight: 700;
-    color: #8a7356;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.ef-display {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    background: none;
-    border: none;
-    padding: 0.15rem 0;
-    cursor: pointer;
-    font-family: inherit;
-    color: inherit;
-    text-align: left;
-    width: 100%;
-    border-radius: 4px;
-    transition: background 0.1s ease;
-    min-height: 1.6rem;
-}
-
-.ef-display:hover { background: rgba(166, 95, 43, 0.06); }
-
-.ef-value-text {
-    font-size: 0.92rem;
-    color: #221812;
-    font-variant-numeric: tabular-nums;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-    flex: 1;
-}
-
-.ef-pencil {
-    color: #c9b9a0;
-    flex-shrink: 0;
-    opacity: 0;
-    transition: opacity 0.1s ease, color 0.1s ease;
-    display: inline-flex;
-}
-
-.ef-display:hover .ef-pencil { opacity: 1; color: #a65f2b; }
-
-.ef-row.is-dirty .ef-pencil { opacity: 0.6; color: #a65f2b; }
-
-.ef-input {
-    width: 100%;
-    border: none;
-    outline: none;
-    background: #faf5ec;
-    border-radius: 6px;
-    padding: 0.4rem 0.55rem;
-    font-size: 0.92rem;
-    font-family: inherit;
-    color: #221812;
-    font-variant-numeric: tabular-nums;
-    box-sizing: border-box;
-    -moz-appearance: textfield;
-}
-
-.ef-input:focus { background: #ffffff; }
-
-.ef-input::-webkit-outer-spin-button,
-.ef-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-
-/* ── Save bar (sticky at bottom of detail pane) ─────────────────────────── */
+/* ── Danger zone + save bar (bottom of detail pane) ─────────────────────── */
 .detail-spacer {
     flex: 1;
-    min-height: 1.5rem;
+    min-height: 0.5rem;
 }
+
+.detail-danger {
+    padding: 0.5rem 1.5rem 0.85rem;
+    border-top: 1px solid rgba(109, 68, 35, 0.06);
+}
+
+.delete-trigger {
+    background: none;
+    border: none;
+    color: #c04033;
+    font-size: 0.78rem;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    font-family: inherit;
+    transition: color 0.1s ease;
+}
+
+.delete-trigger:hover { color: #8a2e23; text-decoration: underline; }
+
+.delete-confirm {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 0.7rem 0.85rem;
+    background: rgba(192, 64, 51, 0.06);
+    border: 1px solid rgba(192, 64, 51, 0.25);
+    border-radius: 8px;
+}
+
+.delete-confirm-text {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #221812;
+}
+
+.delete-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.btn-danger {
+    padding: 0.5rem 1.05rem;
+    border-radius: 8px;
+    border: none;
+    background: #c04033;
+    color: #fff;
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    box-shadow: 0 2px 8px rgba(192, 64, 51, 0.25);
+    transition: background 0.12s ease;
+}
+
+.btn-danger:hover:not([disabled]) { background: #a8362b; }
+.btn-danger[disabled] { opacity: 0.7; cursor: not-allowed; }
 
 .save-bar {
     position: sticky;

--- a/App/Services/ProductService.cs
+++ b/App/Services/ProductService.cs
@@ -31,6 +31,14 @@ public class ProductService
             .ToDictionary(g => g.Key, g => g.ToList());
     }
 
+    public async Task DeleteAsync(int octopusId)
+    {
+        var existing = await _db.Products.FindAsync(octopusId);
+        if (existing == null) return;
+        _db.Products.Remove(existing);
+        await _db.SaveChangesAsync();
+    }
+
     public async Task UpdateAsync(Product update)
     {
         await using var db = _contextFactory.CreateDbContext();

--- a/App/Services/ProductService.cs
+++ b/App/Services/ProductService.cs
@@ -33,10 +33,11 @@ public class ProductService
 
     public async Task DeleteAsync(int octopusId)
     {
-        var existing = await _db.Products.FindAsync(octopusId);
+        await using var db = _contextFactory.CreateDbContext();
+        var existing = await db.Products.FindAsync(octopusId);
         if (existing == null) return;
-        _db.Products.Remove(existing);
-        await _db.SaveChangesAsync();
+        db.Products.Remove(existing);
+        await db.SaveChangesAsync();
     }
 
     public async Task UpdateAsync(Product update)


### PR DESCRIPTION
## Summary

Recovers visual polish + a delete-product feature that lived in a Rider working copy on the redesign branch but was never committed before a branch checkout. The work was found in `.idea/.idea.Klosterbryggeriet/.idea/shelf/Uncommitted_changes_before_Checkout_at_27_04_2026,_11_31_*/shelved.patch` (Rider auto-shelves uncommitted changes when you switch branches).

The shelved patch was based on `ee40dd3` (the WIP redesign commit). Since main now has the merged redesign + a few unrelated commits on top, I applied the patch with `patch -p1` (which succeeded cleanly) and added `EditableField.razor.css` separately — the patch comment explicitly said the `.ef-*` styles should live in that file, but the file itself was never created.

## Changes

**`ProdukterPage.razor`**
- Simplified header: removed the eyebrow + lede, now just title + count badge.
- Status tile is display-only — removed the inline `Available` editor and its support (`_focusAvailableOnRender`, `_availableRef`, `BeginEditAvailable`, `HandleEditKey`, `OnAfterRenderAsync`).
- `Str` / `Alcohol` no longer marked `IsMissing` when 0 (they have valid 0 values), and removed from `MissingOptions`.
- New "Slet produkt" section with confirm flow (`_confirmingDelete`, `_deleting`, `DeleteSelected()`).

**`ProductService.cs`**
- Added `DeleteAsync(int octopusId)`.

**`ProdukterPage.razor.css`**
- Tighter padding / font sizes throughout (page frame, header, filter bar, results line, detail header, detail sections).
- **`.list-pane` and `.detail-pane` got `min-height: 0`** — this is what makes scroll containment actually work in the flex/grid layout.
- Status-tile reduced to display-only (removed `:hover`, `is-dirty`, `editing`, `status-value-btn`, `status-input`).
- New `.detail-danger` / `.delete-trigger` / `.delete-confirm` / `.btn-danger` rules.
- Moved `.ef-*` rules out (see new file below); kept `.ef-grid` here since it's just the layout.

**`EditableField.razor.css` (new)**
- Owns the `.ef-row`, `.ef-display`, `.ef-input`, `.ef-pencil`, `.mangler-chip` styles for the inline edit component.

## Test plan
- [ ] Build succeeds.
- [ ] `/admin/produkter`: left list scrolls when there are many products.
- [ ] Click a product → detail pane shows EditableFields with hover pencil + dirty/editing states.
- [ ] Click "Slet produkt" → confirm prompt → cancel works; confirm actually deletes and reloads.
- [ ] Switching products with unsaved changes still shows the dirty prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)