### PR TITLE
feat: hide unchanged rows from CSV import preview

### DIFF
--- a/App/Services/OctopusService.cs
+++ b/App/Services/OctopusService.cs
@@ -187,6 +187,7 @@ public class OctopusService
         foreach (var dbProduct in dbProducts)
         {
             var row = existingRows.First(r => r.OctopusId == dbProduct.OctopusId);
+            if (row.Available == dbProduct.Available) continue;
             var newStatus = Product.StatusFor(row.Available);
             updates.Add(new PendingUpdate
             {


### PR DESCRIPTION
## Summary
- Forhåndsvisning af import now only lists products where the imported disponibel actually differs from what's in the DB.
- The "X opdateres" counter and `StatusFlipCount` follow naturally from the filtered list, and commit-time work skips no-op writes.

## Test plan
- [ ] Upload a CSV where some rows have unchanged disponibel — confirm only changed rows appear under "Opdateringer".
- [ ] Confirm the "X opdateres" counter matches the rendered list.
- [ ] Confirm new products and warnings still display as before.
- [ ] Click Færdiggør import and confirm the receipt only counts the actually-changed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)