### PR TITLE
fix: prevent manglende felter popup from overflowing viewport

### DIFF
--- a/App/Components/Pages/ProdukterPage.razor.css
+++ b/App/Components/Pages/ProdukterPage.razor.css
@@ -201,7 +201,7 @@
 .missing-menu {
     position: absolute;
     top: calc(100% + 0.4rem);
-    left: 0;
+    right: 0;
     z-index: 100;
     background: #ffffff;
     border: 1px solid rgba(109, 68, 35, 0.14);


### PR DESCRIPTION
## Summary
- The "Manglende felter" dropdown on `/produkter` was anchored with `left: 0` and a `min-width: 230px`. Since the button is the last item in the filter bar (near the right edge), the menu overflowed the viewport and got clipped.
- Anchored the menu to `right: 0` so it expands leftward from the button and stays inside the viewport.

## Test plan
- [ ] Navigate to `/produkter` and click "Manglende felter" — popup is fully visible, right-aligned with the button.
- [ ] Resize the window so the filter bar wraps — popup stays within the viewport.
- [ ] Toggle a checkbox in the popup — interactivity still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)