### PR TITLE
Category dropdown when editing products

### DIFF
--- a/App/Components/EditableSelect.razor
+++ b/App/Components/EditableSelect.razor
@@ -1,0 +1,85 @@
+@* Inline editable dropdown: shows a display value with a pencil; click to edit, blur or Enter/Escape to commit. *@
+
+<div class="ef-row @(IsEditing ? "ef-editing" : "") @(IsDirty ? "is-dirty" : "") @(IsMissing && !IsEditing ? "ef-missing" : "")">
+    <span class="ef-label">
+        @Label
+        @if (IsMissing)
+        {
+            <span class="mangler-chip">Mangler</span>
+        }
+    </span>
+
+    @if (IsEditing)
+    {
+        <select @ref="_inputRef"
+                class="ef-input"
+                @onchange="OnSelectChanged"
+                @onblur="OnEndEdit"
+                @onkeydown="HandleKey">
+            @if (!string.IsNullOrEmpty(InputValue) && !Options.Contains(InputValue))
+            {
+                <option value="@InputValue" selected>@InputValue (ukendt)</option>
+            }
+            @foreach (var opt in Options)
+            {
+                <option value="@opt" selected="@(opt == InputValue)">@opt</option>
+            }
+        </select>
+    }
+    else
+    {
+        <button type="button" class="ef-display" @onclick="OnBeginEdit">
+            <span class="ef-value-text">
+                @if (string.IsNullOrWhiteSpace(DisplayValue))
+                {
+                    <span class="ef-placeholder">—</span>
+                }
+                else
+                {
+                    @DisplayValue
+                }
+            </span>
+            <span class="ef-pencil" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+            </span>
+        </button>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Label { get; set; } = "";
+    [Parameter] public string? DisplayValue { get; set; }
+    [Parameter] public string? InputValue { get; set; }
+    [Parameter] public IEnumerable<string> Options { get; set; } = [];
+    [Parameter] public bool IsEditing { get; set; }
+    [Parameter] public bool IsDirty { get; set; }
+    [Parameter] public bool IsMissing { get; set; }
+    [Parameter] public EventCallback OnBeginEdit { get; set; }
+    [Parameter] public EventCallback OnEndEdit { get; set; }
+    [Parameter] public EventCallback<string?> OnInput { get; set; }
+
+    private ElementReference _inputRef;
+    private bool _wasEditing;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (IsEditing && !_wasEditing)
+        {
+            try { await _inputRef.FocusAsync(); }
+            catch { /* element may not be ready yet */ }
+        }
+        _wasEditing = IsEditing;
+    }
+
+    private Task OnSelectChanged(ChangeEventArgs e) =>
+        OnInput.InvokeAsync(e.Value?.ToString());
+
+    private async Task HandleKey(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" || e.Key == "Escape")
+            await OnEndEdit.InvokeAsync();
+    }
+}

--- a/App/Components/Pages/ProdukterPage.razor
+++ b/App/Components/Pages/ProdukterPage.razor
@@ -257,14 +257,15 @@
                                            OnEndEdit="EndEdit"
                                            OnInput="@(v => d.PdfTitle = v ?? "")" />
 
-                            <EditableField Label="Kategori"
-                                           DisplayValue="@d.Category"
-                                           InputValue="@d.Category"
-                                           IsEditing="@(_editingField == "Category")"
-                                           IsDirty="@FieldDirty("Category")"
-                                           OnBeginEdit='@(() => BeginEdit("Category"))'
-                                           OnEndEdit="EndEdit"
-                                           OnInput="@(v => d.Category = v ?? "")" />
+                            <EditableSelect Label="Kategori"
+                                            Options="_allCats"
+                                            DisplayValue="@d.Category"
+                                            InputValue="@d.Category"
+                                            IsEditing="@(_editingField == "Category")"
+                                            IsDirty="@FieldDirty("Category")"
+                                            OnBeginEdit='@(() => BeginEdit("Category"))'
+                                            OnEndEdit="EndEdit"
+                                            OnInput="@(v => d.Category = v ?? "")" />
 
                             <EditableField Label="Web ID"
                                            DisplayValue="@d.WebId.ToString()"


### PR DESCRIPTION
## Summary
- New `EditableSelect.razor` component — sibling to `EditableField`, identical inline-edit chrome but renders a `<select>` in edit mode
- `Kategori` field on `/produkter` swapped from free-text `EditableField` to `EditableSelect`, populated from `_allCats` (distinct categories already in use across products)
- Legacy stored values not in the dropdown are preserved as a `(ukendt)` fallback option, so existing data is never silently overwritten

Outcome: prevents typos and spelling drift (e.g. "fadøl" vs "Fadøl") that polluted the filter dropdown and `Category-asc` sort. New canonical categories still flow in the same way — assign one product to a category created on `/kategorier` and it appears in the dropdown.

## Test plan
- [ ] `dotnet build` is clean
- [ ] Open `/produkter`, select a product, click pencil on **Kategori** — a `<select>` appears with all distinct categories, current value preselected
- [ ] Pick a different option, blur — dirty indicator appears, **Gem** enables; click Gem and confirm persistence after reload
- [ ] Press **Esc** mid-edit — exits edit mode cleanly
- [ ] Legacy fallback: a product whose Category isn't in `_allCats` shows the `(ukendt)` option preselected
- [ ] Filter dropdown at the top of `/produkter` still works (regression check — same `_allCats`)
- [ ] Other `EditableField` usages (rest of `ProdukterPage`, `KategoriPage`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)