### PR TITLE
Reorder CSV import preview and keep fadøl badge inline

### DIFF
--- a/App/Components/Pages/ImporterCsv.razor
+++ b/App/Components/Pages/ImporterCsv.razor
@@ -133,32 +133,6 @@
                 </div>
             }
 
-            @if (preview.PendingUpdates.Count > 0)
-            {
-                <h3 class="preview-section-title">Opdateringer (@preview.PendingUpdates.Count)</h3>
-                <ul class="diff-list">
-                    @foreach (var u in preview.PendingUpdates)
-                    {
-                        <li class="diff-row @DiffRowClass(u)">
-                            <span class="diff-marker">~</span>
-                            <span class="diff-id">#@u.OctopusId</span>
-                            <span class="diff-title">@(string.IsNullOrWhiteSpace(u.OctopusTitle) ? "—" : u.OctopusTitle)</span>
-                            @if (u.Kind == PendingProductKind.DraftBeer)
-                            {
-                                <span class="kind-tag">fadøl</span>
-                            }
-                            <span class="diff-detail">
-                                @u.PreviousAvailable → @u.NewAvailable
-                                @if (u.StatusFlipped)
-                                {
-                                    <span class="diff-status"> (@StatusLabel(u.PreviousStatus) → @StatusLabel(u.NewStatus))</span>
-                                }
-                            </span>
-                        </li>
-                    }
-                </ul>
-            }
-
             @if (preview.PendingNewProducts.Count > 0)
             {
                 <h3 class="preview-section-title">Nye produkter (@preview.PendingNewProducts.Count)</h3>
@@ -324,6 +298,34 @@
                 </div>
             }
 
+            @if (preview.PendingUpdates.Count > 0)
+            {
+                <h3 class="preview-section-title">Opdateringer (@preview.PendingUpdates.Count)</h3>
+                <ul class="diff-list">
+                    @foreach (var u in preview.PendingUpdates)
+                    {
+                        <li class="diff-row @DiffRowClass(u)">
+                            <span class="diff-marker">~</span>
+                            <span class="diff-id">#@u.OctopusId</span>
+                            <span class="diff-title">
+                                <span class="diff-title-text">@(string.IsNullOrWhiteSpace(u.OctopusTitle) ? "—" : u.OctopusTitle)</span>
+                                @if (u.Kind == PendingProductKind.DraftBeer)
+                                {
+                                    <span class="kind-tag">fadøl</span>
+                                }
+                            </span>
+                            <span class="diff-detail">
+                                @u.PreviousAvailable → @u.NewAvailable
+                                @if (u.StatusFlipped)
+                                {
+                                    <span class="diff-status"> (@StatusLabel(u.PreviousStatus) → @StatusLabel(u.NewStatus))</span>
+                                }
+                            </span>
+                        </li>
+                    }
+                </ul>
+            }
+
             @if (preview.PendingUpdates.Count == 0 && preview.PendingNewProducts.Count == 0)
             {
                 <p class="receipt-empty">Ingen ændringer i denne import.</p>
@@ -477,11 +479,13 @@
                         <li class="diff-row diff-add">
                             <span class="diff-marker">+</span>
                             <span class="diff-id">#@c.OctopusId</span>
-                            <span class="diff-title">@(string.IsNullOrWhiteSpace(c.OctopusTitle) ? "—" : c.OctopusTitle)</span>
-                            @if (c.Kind == PendingProductKind.DraftBeer)
-                            {
-                                <span class="kind-tag">fadøl</span>
-                            }
+                            <span class="diff-title">
+                                <span class="diff-title-text">@(string.IsNullOrWhiteSpace(c.OctopusTitle) ? "—" : c.OctopusTitle)</span>
+                                @if (c.Kind == PendingProductKind.DraftBeer)
+                                {
+                                    <span class="kind-tag">fadøl</span>
+                                }
+                            </span>
                             <span class="diff-detail">Disponibel=@c.Available</span>
                         </li>
                     }
@@ -490,11 +494,13 @@
                         <li class="diff-row @DiffRowClass(u)">
                             <span class="diff-marker">~</span>
                             <span class="diff-id">#@u.OctopusId</span>
-                            <span class="diff-title">@(string.IsNullOrWhiteSpace(u.OctopusTitle) ? "—" : u.OctopusTitle)</span>
-                            @if (u.Kind == PendingProductKind.DraftBeer)
-                            {
-                                <span class="kind-tag">fadøl</span>
-                            }
+                            <span class="diff-title">
+                                <span class="diff-title-text">@(string.IsNullOrWhiteSpace(u.OctopusTitle) ? "—" : u.OctopusTitle)</span>
+                                @if (u.Kind == PendingProductKind.DraftBeer)
+                                {
+                                    <span class="kind-tag">fadøl</span>
+                                }
+                            </span>
                             <span class="diff-detail">
                                 @u.PreviousAvailable → @u.NewAvailable
                                 @if (u.StatusFlipped)

--- a/App/Components/Pages/ImporterCsv.razor.css
+++ b/App/Components/Pages/ImporterCsv.razor.css
@@ -986,9 +986,22 @@ select.row-input {
 
 .diff-title {
     font-family: inherit;
-    white-space: nowrap;
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.diff-title-text {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.diff-title > .kind-tag {
+    flex-shrink: 0;
+    margin-left: 0;
 }
 
 .diff-detail {

--- a/App/Components/Pages/ProdukterPage.razor
+++ b/App/Components/Pages/ProdukterPage.razor
@@ -308,7 +308,7 @@
                                             DisplayValue="@d.Category"
                                             InputValue="@d.Category"
                                             IsEditing="@(_editingField == "Category")"
-                                            IsDirty="@FieldDirty("Category")"
+                                            IsDirty="@ProductFieldDirty("Category")"
                                             OnBeginEdit='@(() => BeginEdit("Category"))'
                                             OnEndEdit="EndEdit"
                                             OnInput="@(v => d.Category = v ?? "")" />


### PR DESCRIPTION
## Summary

- New CSV import preview now shows **Nye produkter** before **Opdateringer** so the manual-input list demands attention first and the auto-applied stock changes sit below as a quieter log.
- Fadøl `kind-tag` is now nested inside `.diff-title` (a flex container with an ellipsis-aware `.diff-title-text` child) in all three diff-row spots — preview update, receipt created, receipt updated. The row stays a 4-column grid, so the trailing `5 → 7` numbers no longer wrap to a new line whenever the badge appears.

## Test plan

- [x] `dotnet build App/BlazorApp.csproj` clean
- [x] `dotnet test --filter "FullyQualifiedName~Csv"` — 18 / 18 passing
- [ ] Visual check on `/importer-csv` after uploading `sample-data/fadoel-import-demo.csv`:
  - "Nye produkter (4)" section appears above "Opdateringer (6)" in the preview
  - Fadøl rows in *Opdateringer* render `~ #ID Title fadøl 5 → 7` on a single line
  - Long titles ellipsize but the `fadøl` badge and number arrow stay visible
  - After *Færdiggør import*, the *Seneste import* receipt also shows `+`/`~` fadøl rows on one line
- [ ] Mobile/<560px responsive check

🤖 Generated with [Claude Code](https://claude.com/claude-code)