### PR TITLE
Make sidebar nav-group dividers easier to see

### DIFF
--- a/App/Components/Layout/NavMenu.razor.css
+++ b/App/Components/Layout/NavMenu.razor.css
@@ -81,8 +81,8 @@
 
 .nav-divider {
     border: 0;
-    border-top: 1px solid rgba(243, 230, 204, 0.1);
-    margin: 0.6rem 1.5rem;
+    border-top: 1px solid rgba(243, 230, 204, 0.2);
+    margin: 0.85rem 1.5rem;
 }
 
 .nav-item ::deep .nav-link {


### PR DESCRIPTION
## Summary
- Bump `.nav-divider` opacity 0.1 → 0.2 (matches the design vocabulary already used elsewhere in `NavMenu.razor.css`)
- Widen vertical margin 0.6rem → 0.85rem so the section break reads as a deliberate boundary

## Test plan
- [ ] Run the app, view the sidebar at desktop width, and confirm the three dividers (Oversigt / Importer CSV, Produkter / Prisliste, Kategorier / Fadølsliste) are clearly visible without looking heavy
- [ ] Hover and active states on adjacent nav links should still look correct (no clash with the `#c99a4e` active highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)